### PR TITLE
Merge path-level OpenAPI parameters

### DIFF
--- a/src/mockloop_mcp/generator.py
+++ b/src/mockloop_mcp/generator.py
@@ -141,6 +141,16 @@ def _generate_mock_data_from_schema(schema: dict[str, Any]) -> Any:
     return "mock_data"
 
 
+def _merge_parameters(
+    path_parameters: list[dict[str, Any]], operation_parameters: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    merged: dict[tuple[Any, Any], dict[str, Any]] = {}
+    for param in path_parameters + operation_parameters:
+        if isinstance(param, dict):
+            merged[(param.get("in"), param.get("name"))] = param
+    return list(merged.values())
+
+
 def generate_mock_api(
     spec_data: dict[str, Any],
     output_base_dir: str | Path | None = None,
@@ -295,6 +305,7 @@ def generate_mock_api(
         routes_code_parts: list[str] = []
         paths = spec_data.get("paths", {})
         for path_url, methods in paths.items():
+            path_parameters = methods.get("parameters", [])
             for method, details in methods.items():
                 valid_methods = [
                     "get",
@@ -309,7 +320,9 @@ def generate_mock_api(
                 if method.lower() not in valid_methods:
                     continue
                 path_params = ""
-                parameters = details.get("parameters", [])
+                parameters = _merge_parameters(
+                    path_parameters, details.get("parameters", [])
+                )
                 path_param_list = []
                 for param in parameters:
                     if param.get("in") == "path":

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -19,5 +19,43 @@ def test_mock_api_generation():
         pass
 
 
+def test_path_level_parameters_are_added_to_generated_routes(tmp_path):
+    spec_data = {
+        "openapi": "3.0.0",
+        "info": {"title": "Path Params", "version": "1.0.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "parameters": [
+                    {
+                        "name": "item_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "integer"},
+                    }
+                ],
+                "get": {
+                    "summary": "Get item",
+                    "responses": {"200": {"description": "OK"}},
+                },
+            }
+        },
+    }
+
+    output_dir = generate_mock_api(
+        spec_data=spec_data,
+        output_base_dir=tmp_path,
+        mock_server_name="path_param_api",
+        auth_enabled=False,
+        webhooks_enabled=False,
+        admin_ui_enabled=False,
+        storage_enabled=False,
+    )
+
+    main_py_content = (output_dir / "main.py").read_text()
+
+    assert "async def mock_get_items_item_id(" in main_py_content
+    assert "item_id: int" in main_py_content
+
+
 if __name__ == "__main__":
     test_mock_api_generation()


### PR DESCRIPTION
## Summary

- merge OpenAPI path-item parameters into each generated operation
- keep operation-level parameters authoritative when they share the same `in` and `name`
- add a generator test for a shared path parameter

## Validation

- `pytest tests/unit/test_generator.py -q`

## Notes

- `pytest tests/unit -q` currently reports 125 passed and 2 unrelated failures while importing `mockloop_mcp.main`: `FastMCP.__init__()` rejects the existing `description` argument with the installed MCP dependency.
