### PR TITLE
test: add Xquik OpenAPI 3.1 mock fixture

### DIFF
--- a/tests/fixtures/xquik_openapi31.json
+++ b/tests/fixtures/xquik_openapi31.json
@@ -1,0 +1,84 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0",
+    "description": "REST API for X automation workflows"
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "summary": "Search Tweets",
+        "tags": ["x"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweet search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TweetSearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      }
+    },
+    "schemas": {
+      "TweetSearchResponse": {
+        "type": "object",
+        "required": ["tweets"],
+        "properties": {
+          "tweets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tweet"
+            }
+          }
+        }
+      },
+      "Tweet": {
+        "type": "object",
+        "required": ["id", "text"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -19,5 +19,24 @@ def test_mock_api_generation():
         pass
 
 
+def test_xquik_openapi31_mock_api_generation(tmp_path):
+    spec_data = load_api_specification("tests/fixtures/xquik_openapi31.json")
+
+    output_dir = generate_mock_api(
+        spec_data=spec_data,
+        output_base_dir=tmp_path,
+        mock_server_name="xquik_api_mock",
+        auth_enabled=False,
+        webhooks_enabled=False,
+        admin_ui_enabled=False,
+        storage_enabled=False,
+    )
+
+    generated_main = (output_dir / "main.py").read_text(encoding="utf-8")
+    assert '@app.get("/api/v1/x/tweets/search", summary="Search Tweets")' in generated_main
+    assert "mock_get_api_v1_x_tweets_search" in generated_main
+    assert "#/components/schemas/TweetSearchResponse" in generated_main
+
+
 if __name__ == "__main__":
     test_mock_api_generation()


### PR DESCRIPTION
## Summary

- Add a local Xquik OpenAPI 3.1 fixture for mock generation.
- Assert the generated FastAPI route and schema reference placeholder.

## Validation

- `uv run pytest tests/unit/test_generator.py`
